### PR TITLE
Fix // in URL which breaks Cloudflare API since April 2020

### DIFF
--- a/cf-ddns.sh
+++ b/cf-ddns.sh
@@ -290,9 +290,9 @@ do_record_update () {
 
 #Main
 ###############
-# Remove any trailing slashes from storage_dir and cf_api_url
-storage_dir=${storage_dir%%+(/)}
-cf_api_url=${cf_api_url%%+(/)}
+# Remove the last trailing slash from storage_dir and cf_api_url
+storage_dir=${storage_dir%/}
+cf_api_url=${cf_api_url%/}
 
 # Show help and exit if no option was passed in the command line
 


### PR DESCRIPTION
The previous form ${storage_dir%%+(/)} and ${cf_api_url%%+(/)} ain't working on my prod env, It probably needs the extglob option which ain't enabled by default. This cause // in url which cause problem with Couldflare API since about mid April 2020.

Solution: just remove the last trailing slash.